### PR TITLE
Ensure make build works correcly inside Docker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ build:
 	export GOOS=linux
 	export GOARCH=amd64
 	dep ensure -v
-	go build -o build/_output/onos-config-manager ./onos-config-manager
+	go build -o build/_output/onos-config-manager ./cmd/onos-config-manager
 
 run:
 	dep ensure -v
-	go run onos-config-manager/config-manager.go
+	go run cmd/onos-config-manager/config-manager.go

--- a/build/dev-docker/Dockerfile
+++ b/build/dev-docker/Dockerfile
@@ -10,4 +10,8 @@ RUN mkdir release && \
     rmdir release && \
     rm dep-*.sha256
 
+RUN mkdir -p /go/src/github.com/opennetworkinglab/onos-config
+
+WORKDIR "/go/src/github.com/opennetworkinglab/onos-config"
+
 ENTRYPOINT ["make"]


### PR DESCRIPTION
To build the Docker container:
```
docker build -t onos-config:0.1 build/dev-docker
```

To run the Docker container:
```
docker run -it -v `pwd`:/go/src/github.com/opennetworkinglab/onos-config onos-config:0.1 build
```